### PR TITLE
🐛 Fix: 토큰을 쿠키로 관리하기 위해 http->https로 연결되게 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 .env.local
 .env.development
 .env.production
+*.pem
 
 # Editor directories and files
 .vscode/*

--- a/src/pages/setting/index.jsx
+++ b/src/pages/setting/index.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Toast from "../../components/toast/Toast";
 import CheckMsg from "../../components/toast/CheckMsg";
 import { theme } from "../../styles/themes";
@@ -8,6 +8,7 @@ import { LuPencilLine } from "react-icons/lu";
 import { IoCheckmarkOutline } from "react-icons/io5";
 import { FaPlus } from "react-icons/fa";
 import Linkbox from "../../components/Linkbox";
+import { TokenReq } from "../../apis/axiosInstance";
 
 const Container = styled.div`
   display: flex;
@@ -81,10 +82,24 @@ const Username = styled.input`
 
 function Setting() {
   const [profileImg, setProfileImg] = useState(""); // 프로필 이미지 상태
+  const [subImg, setSubImg] = useState(""); // 서버 요청용
   const [name, setName] = useState("username"); // 이름 상태
   const [toggle, setToggle] = useState(false); // 편집 버튼 상태
   const [toastVisible, setToastVisible] = useState(false); // 토스트 상태
   const [message, setMessage] = useState(""); // 토스트 메세지
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await TokenReq("/users/getInfo")
+        .then((res) => res.data.result)
+        .then((userData) => {
+          setProfileImg(userData.profileImage);
+          setSubImg(userData.profileImage);
+          setName(userData.nickname);
+        });
+    };
+    fetchData();
+  }, []);
 
   const handleImg = () => {
     const input = document.createElement("input");
@@ -92,6 +107,8 @@ function Setting() {
     input.accept = "image/*";
     input.onchange = (e) => {
       const file = e.target.files[0];
+      setSubImg(file);
+
       if (file) {
         const reader = new FileReader();
         reader.onloadend = () => {
@@ -125,8 +142,21 @@ function Setting() {
 
     setToggle(!toggle);
     toggle &&
-      (setMessage(<CheckMsg msg="변경이 완료되었습니다" />),
+      (postData(subImg, name),
+      setMessage(<CheckMsg msg="변경이 완료되었습니다" />),
       setToastVisible(true));
+  };
+
+  const postData = async (img, name) => {
+    console.log(img, name);
+
+    const formData = new FormData();
+    formData.append("profileImage", img);
+    formData.append("nickname", name);
+
+    await TokenReq.patch("/users/update", formData, {
+      headers: { "Content-Type": "multipary/form-data" },
+    });
   };
 
   return (

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import fs from "fs";
 import path from "path";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    https: {
+      key: fs.readFileSync(path.resolve(__dirname, "localhost-key.pem")),
+      cert: fs.readFileSync(path.resolve(__dirname, "localhost.pem")),
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"), // ⬅ 절대경로 설정


### PR DESCRIPTION
## #️⃣ 이슈 번호

close:

- #64 

## 📝 작업 내용

> vite 설정에서 로컬에서도 https로 접속되게 설정

## 📝 예외 처리

> X

## 💬 리뷰 요구사항(선택)

> https://hojun-dev.tistory.com/entry/React-localhost-https-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0
이거 보고 인증서 발급하면 됩니당


> [!CAUTION]
> 발급받은 인증서는 깃허브에 올라가면 안되기때문에 .gitignore에 *.pem 추가되어있는지 확인해보기!
